### PR TITLE
~ tested examples against https://shexstatements.toolforge.org/

### DIFF
--- a/examples/emptyvalues.csv
+++ b/examples/emptyvalues.csv
@@ -1,9 +1,11 @@
-@painting,P31,Q3305213,,
-@painting,P571,xsd:dateTime,#date of creation
-@painting,P572,xsd:dateTime,   , 
-@painting,P276,.,+,  
-@painting,P1476,.,+
-@painting,P195,.,+
-@painting,P170,@creator,+,#creator of painting
-@creator,P2561,LITERAL,#name
-
+wd,<http://www.wikidata.org/entity/>,,,
+wdt,<http://www.wikidata.org/prop/direct/>,,,
+xsd,<http://www.w3.org/2001/XMLSchema#>,,,
+@painting,wdt:P31,wd:Q3305213,,
+@painting,wdt:P571,@@xsd:dateTime,#date of creation
+@painting,wdt:P572,@@xsd:dateTime,   ,
+@painting,wdt:P276,.,+,
+@painting,wdt:P1476,.,+
+@painting,wdt:P195,.,+
+@painting,wdt:P170,@creator,+,#creator of painting
+@creator,wdt:P2561,LITERAL,#name

--- a/examples/example.csv
+++ b/examples/example.csv
@@ -1,9 +1,12 @@
-@painting,P31,Q3305213
-@painting,P571,xsd:dateTime,#date of creation
-@painting,P572,xsd:dateTime
-@painting,P276,.,+
-@painting,P1476,.,+
-@painting,P195,.,+
-@painting,P170,@creator,+,#creator of painting
-@creator,P2561,LITERAL,#name
+wd,<http://www.wikidata.org/entity/>,,,
+wdt,<http://www.wikidata.org/prop/direct/>,,,
+xsd,<http://www.w3.org/2001/XMLSchema#>,,,
+@painting,wdt:P31,wd:Q3305213
+@painting,wdt:P571,@@xsd:dateTime,#date of creation
+@painting,wdt:P572,@@xsd:dateTime
+@painting,wdt:P276,.,+
+@painting,wdt:P1476,.,+
+@painting,wdt:P195,.,+
+@painting,wdt:P170,@creator,+,#creator of painting
+@creator,wdt:P2561,LITERAL,#name
 

--- a/examples/languageheader.csv
+++ b/examples/languageheader.csv
@@ -1,4 +1,3 @@
-Name,Property,Value,Cardinality,Comments
 wd,<http://www.wikidata.org/entity/>,,,
 wdt,<http://www.wikidata.org/prop/direct/>,,,
 xsd,<http://www.w3.org/2001/XMLSchema#>,,,

--- a/examples/tests/tvseriesnegativeprop.csv
+++ b/examples/tests/tvseriesnegativeprop.csv
@@ -1,6 +1,6 @@
-wd|<http://www.wikidata.org/entity/>,,,
-wdt|<http://www.wikidata.org/prop/direct/>,,,
-xsd|<http://www.w3.org/2001/XMLSchema#>,,,
+wd|<http://www.wikidata.org/entity/>|||
+wdt|<http://www.wikidata.org/prop/direct/>|||
+xsd|<http://www.w3.org/2001/XMLSchema#>|||
 
 @tvseries|wdt:P31|wd:Q5398426|# instance of a tvseries
 @tvseries|wdt:P136|@genre|*|# genre

--- a/examples/tvseries.csv
+++ b/examples/tvseries.csv
@@ -1,6 +1,6 @@
-wd|<http://www.wikidata.org/entity/>,,,
-wdt|<http://www.wikidata.org/prop/direct/>,,,
-xsd|<http://www.w3.org/2001/XMLSchema#>,,,
+wd|<http://www.wikidata.org/entity/>|||
+wdt|<http://www.wikidata.org/prop/direct/>|||
+xsd|<http://www.w3.org/2001/XMLSchema#>|||
 
 @tvseries|wdt:P31|wd:Q5398426|# instance of a tvseries
 @tvseries|wdt:P136|@genre|*|# genre

--- a/examples/wikidata/pandemic.csv
+++ b/examples/wikidata/pandemic.csv
@@ -6,6 +6,6 @@ xsd,<http://www.w3.org/2001/XMLSchema#>,,,
 
 @pandemic,wdt:P31,wd:Q12184,,# instance of a pandemic
 @pandemic,wdt:P580,.,1,#start time of the pandemic
-@pandemic,wdt:P582,.,1,end time of the pandemic
+@pandemic,wdt:P582,.,1,#end time of the pandemic
 @pandemic,wdt:P1182,.,*,# number of deaths
 @pandemic,wdt:P828,.,*,# has cause


### PR DESCRIPTION
## controversial changes
* examples/languageheader.csv - removed header (didn't see how to make it parse)

## non-controversial changes
* examples/emptyvalues.csv - added prefixes
* examples/example.csv - added prefixes
* examples/tests/tvseriesnegativeprop.csv - changed trailing ','s to '|'s
* examples/tvseries.csv - changed trailing ','s to '|'s
* examples/wikidata/pandemic.csv - added '#' delimiter

## not done
* examples/languageap.csv - syntax seemed far from other examples.