### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/shexstatements/shexfromcsv.py
+++ b/shexstatements/shexfromcsv.py
@@ -75,14 +75,18 @@ class CSV:
                 raw_path = filepath.strip()
                 if not raw_path:
                     raise ValueError("Empty filename is not allowed")
+                # Normalize the user-supplied path.
                 normalized_path = os.path.normpath(raw_path)
+                # Disallow absolute paths supplied by the caller.
+                if os.path.isabs(normalized_path):
+                    raise ValueError("Absolute paths are not allowed")
                 # Resolve the path against a safe base directory (current working directory).
-                base_dir = os.getcwd()
-                candidate_path = os.path.normpath(os.path.join(base_dir, normalized_path))
+                base_dir = os.path.realpath(os.getcwd())
+                real_candidate = os.path.realpath(os.path.join(base_dir, normalized_path))
                 # Ensure the final path is within the base directory to prevent path traversal.
-                if os.path.commonpath([base_dir, candidate_path]) != os.path.abspath(base_dir):
+                if os.path.commonpath([base_dir, real_candidate]) != base_dir:
                     raise ValueError("Access to the specified file path is not allowed")
-                with open(candidate_path) as csvfile:
+                with open(real_candidate) as csvfile:
                     csvreader = csv.reader(csvfile, delimiter=delim)
                     rowno = 0
                     for row in csvreader:

--- a/shexstatements/shexfromcsv.py
+++ b/shexstatements/shexfromcsv.py
@@ -80,8 +80,8 @@ class CSV:
                 # Disallow absolute paths supplied by the caller.
                 if os.path.isabs(normalized_path):
                     raise ValueError("Absolute paths are not allowed")
-                # Resolve the path against a safe base directory (current working directory).
-                base_dir = os.path.realpath(os.getcwd())
+                # Resolve the path against a safe base directory (directory of this module).
+                base_dir = os.path.dirname(os.path.realpath(__file__))
                 real_candidate = os.path.realpath(os.path.join(base_dir, normalized_path))
                 # Ensure the final path is within the base directory to prevent path traversal.
                 if os.path.commonpath([base_dir, real_candidate]) != base_dir:

--- a/shexstatements/shexfromcsv.py
+++ b/shexstatements/shexfromcsv.py
@@ -72,14 +72,17 @@ class CSV:
             data = ""
             if filename:
                 # Validate and normalize the path while allowing relative subdirectories.
-                normalized_path = os.path.normpath(filepath.strip())
-                if not normalized_path:
+                raw_path = filepath.strip()
+                if not raw_path:
                     raise ValueError("Empty filename is not allowed")
-                if os.path.isabs(normalized_path):
-                    raise ValueError("Absolute paths are not allowed")
-                if normalized_path == ".." or normalized_path.startswith(".." + os.path.sep):
-                    raise ValueError("Path traversal is not allowed")
-                with open(normalized_path) as csvfile:
+                normalized_path = os.path.normpath(raw_path)
+                # Resolve the path against a safe base directory (current working directory).
+                base_dir = os.getcwd()
+                candidate_path = os.path.normpath(os.path.join(base_dir, normalized_path))
+                # Ensure the final path is within the base directory to prevent path traversal.
+                if os.path.commonpath([base_dir, candidate_path]) != os.path.abspath(base_dir):
+                    raise ValueError("Access to the specified file path is not allowed")
+                with open(candidate_path) as csvfile:
                     csvreader = csv.reader(csvfile, delimiter=delim)
                     rowno = 0
                     for row in csvreader:

--- a/shexstatements/shexfromspreadsheet.py
+++ b/shexstatements/shexfromspreadsheet.py
@@ -6,6 +6,7 @@
 
 from os import remove
 from os.path import splitext
+import tempfile
 
 from odf.opendocument import load
 from odf.table import TableCell, TableRow
@@ -46,13 +47,23 @@ class Spreadsheet:
 
             if(file_extension in {".xlsx", ".xlsm", ".xltx", ".xltm"}):
                 wb = None
+                temp_path = None
                 if stream is not None:
-                    with open("tmp" + filepath, "wb") as sf:
-                        sf.write(stream)
-                    sf.close()
-                    filepath = "tmp" + filepath
+                    fd, temp_path = tempfile.mkstemp(suffix=file_extension)
+                    try:
+                        with open(fd, "wb") as sf:
+                            sf.write(stream)
+                    except TypeError:
+                        # Fallback for environments where opening by fd is not supported
+                        import os
+                        os.close(fd)
+                        with open(temp_path, "wb") as sf:
+                            sf.write(stream)
+                    filepath_to_open = temp_path
+                else:
+                    filepath_to_open = filepath
 
-                wb = load_workbook(filepath)
+                wb = load_workbook(filepath_to_open)
                 for ws in wb.worksheets:
                     for i in range(1, ws.max_row+1):
                         line = list()
@@ -63,8 +74,8 @@ class Spreadsheet:
                         line = "|".join(line)
                         data = data + line + "\n"
 
-                if stream is not None:
-                    remove(filepath)
+                if stream is not None and temp_path is not None:
+                    remove(temp_path)
 
             elif(file_extension in {".xls"}):
                 wb = None
@@ -84,13 +95,23 @@ class Spreadsheet:
 
             elif(file_extension in {".ods"}):
                 wb = None
+                temp_path = None
                 if stream is not None:
-                    with open("tmp" + filepath, "wb") as sf:
-                        sf.write(stream)
-                    sf.close()
-                    filepath = "tmp" + filepath
+                    fd, temp_path = tempfile.mkstemp(suffix=file_extension)
+                    try:
+                        with open(fd, "wb") as sf:
+                            sf.write(stream)
+                    except TypeError:
+                        # Fallback for environments where opening by fd is not supported
+                        import os
+                        os.close(fd)
+                        with open(temp_path, "wb") as sf:
+                            sf.write(stream)
+                    filepath_to_open = temp_path
+                else:
+                    filepath_to_open = filepath
 
-                wb = load(filepath)
+                wb = load(filepath_to_open)
                 wb = wb.spreadsheet
                 rows = wb.getElementsByType(TableRow)
                 for row in rows:
@@ -101,8 +122,8 @@ class Spreadsheet:
                             line.append(str(cell))
                     data = data+"|".join(line) + "\n"
 
-                if stream is not None:
-                    remove(filepath)
+                if stream is not None and temp_path is not None:
+                    remove(temp_path)
 
             shexstatement = CSV.generate_shex_from_data_string(data)
         except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/johnsamuelwrites/ShExStatements/security/code-scanning/8](https://github.com/johnsamuelwrites/ShExStatements/security/code-scanning/8)

In general, to fix uncontrolled path usage you must (1) normalize the user‑provided path, and (2) enforce that the resulting path is within a designated safe directory or an explicit allow‑list, rejecting anything else. Simply disallowing absolute paths and `..` segments is not sufficient if the application can have a sensitive working directory.

In this code, the minimal, backward‑compatible fix is to introduce a single “safe root” directory (e.g. the process’ current working directory) for all file accesses in `generate_shex_from_csv` when `filename` is `True`. We then:

1. Strip and normalize the provided `filepath` to remove redundant separators and `..` segments.
2. Reject empty paths.
3. Build a full path with `os.path.join(base_dir, normalized_path)`.
4. Normalize that full path again and verify that it still resides under `base_dir` using a robust prefix check (`os.path.commonpath`), which correctly handles cases where simple string `startswith` would fail.
5. Use this `safe_fullpath` when opening the file.

This keeps existing functionality (relative paths still work) but prevents traversal outside the chosen base directory and blocks absolute paths implicitly (since `os.path.join(base_dir, abs_path)` discards `base_dir`, which will then fail the commonpath check). We only need to modify `shexstatements/shexfromcsv.py` inside the `if filename:` branch; no changes are required in `application.py`. We will add the new logic in place of the current ad‑hoc normalized_path checks, reusing the existing `import os`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
