### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/shexstatements/shexfromspreadsheet.py
+++ b/shexstatements/shexfromspreadsheet.py
@@ -6,6 +6,7 @@
 
 from os import remove
 from os.path import splitext
+import tempfile
 
 from odf.opendocument import load
 from odf.table import TableCell, TableRow
@@ -46,13 +47,23 @@ class Spreadsheet:
 
             if(file_extension in {".xlsx", ".xlsm", ".xltx", ".xltm"}):
                 wb = None
+                temp_path = None
                 if stream is not None:
-                    with open("tmp" + filepath, "wb") as sf:
-                        sf.write(stream)
-                    sf.close()
-                    filepath = "tmp" + filepath
+                    fd, temp_path = tempfile.mkstemp(suffix=file_extension)
+                    try:
+                        with open(fd, "wb") as sf:
+                            sf.write(stream)
+                    except TypeError:
+                        # Fallback for environments where opening by fd is not supported
+                        import os
+                        os.close(fd)
+                        with open(temp_path, "wb") as sf:
+                            sf.write(stream)
+                    filepath_to_open = temp_path
+                else:
+                    filepath_to_open = filepath
 
-                wb = load_workbook(filepath)
+                wb = load_workbook(filepath_to_open)
                 for ws in wb.worksheets:
                     for i in range(1, ws.max_row+1):
                         line = list()
@@ -63,8 +74,8 @@ class Spreadsheet:
                         line = "|".join(line)
                         data = data + line + "\n"
 
-                if stream is not None:
-                    remove(filepath)
+                if stream is not None and temp_path is not None:
+                    remove(temp_path)
 
             elif(file_extension in {".xls"}):
                 wb = None
@@ -84,13 +95,23 @@ class Spreadsheet:
 
             elif(file_extension in {".ods"}):
                 wb = None
+                temp_path = None
                 if stream is not None:
-                    with open("tmp" + filepath, "wb") as sf:
-                        sf.write(stream)
-                    sf.close()
-                    filepath = "tmp" + filepath
+                    fd, temp_path = tempfile.mkstemp(suffix=file_extension)
+                    try:
+                        with open(fd, "wb") as sf:
+                            sf.write(stream)
+                    except TypeError:
+                        # Fallback for environments where opening by fd is not supported
+                        import os
+                        os.close(fd)
+                        with open(temp_path, "wb") as sf:
+                            sf.write(stream)
+                    filepath_to_open = temp_path
+                else:
+                    filepath_to_open = filepath
 
-                wb = load(filepath)
+                wb = load(filepath_to_open)
                 wb = wb.spreadsheet
                 rows = wb.getElementsByType(TableRow)
                 for row in rows:
@@ -101,8 +122,8 @@ class Spreadsheet:
                             line.append(str(cell))
                     data = data+"|".join(line) + "\n"
 
-                if stream is not None:
-                    remove(filepath)
+                if stream is not None and temp_path is not None:
+                    remove(temp_path)
 
             shexstatement = CSV.generate_shex_from_data_string(data)
         except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/johnsamuelwrites/ShExStatements/security/code-scanning/5](https://github.com/johnsamuelwrites/ShExStatements/security/code-scanning/5)

In general, fix uncontrolled path usage by (a) not trusting the client‑supplied filename, (b) normalizing and constraining the path to a dedicated upload directory, and/or (c) replacing the provided name with a safe server‑generated name (or using `secure_filename`). Here, we do not actually need the original client filename for anything other than extension detection; the content is passed via `stream`. The safest minimal fix is therefore to (1) ignore the user’s filename for filesystem paths, (2) generate a unique temporary filename in a safe temp directory, and (3) use that path both for `open()` and for `remove()`.

Concretely:

- In `generate_shex_from_spreadsheet`, import `os` (or `tempfile`) and create a temp filename using `tempfile.NamedTemporaryFile(delete=False)` or `tempfile.mkstemp()` for the cases where `stream is not None`. Write `stream` into this safe path, and use that path for `load_workbook` / `load` and for `remove()`. Do **not** concatenate `"tmp" + filepath` or otherwise reuse the user‑provided name in a filesystem path. The original `filepath` parameter is still fine to use with `splitext()` to determine `file_extension`, but not as a path.
- Only modify code in `shexstatements/shexfromspreadsheet.py` within the shown method. `shexstatements/application.py` can stay unchanged because it just passes through the client filename; the dangerous part is using that string as a path in `generate_shex_from_spreadsheet`.

This preserves existing behavior (read spreadsheet from the uploaded stream, delete the temporary file afterward) while ensuring that all actual filesystem paths are generated by the server and not influenced by user input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
